### PR TITLE
Migrate docs and add .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+### Listening port
+SERVER_PORT=3000
+
+
+### Authentication
+JWT_SECRET=some_secret_from_journal
+
+### New Relic
+NEW_RELIC_ENABLED=false
+NEW_RELIC_LICENSE_KEY=
+NEW_RELIC_APP_NAME=
+NEW_RELIC_NO_CONFIG_FILE=true
+NEW_RELIC_LOG_LEVEL=info

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ docker-compose.override.yml
 *.tmp.ts
 data/
 dist/
+
+#sqlite output file
+data.db

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig.build.json",
     "format": "prettier --write \"src/**/*.ts\"",
     "start": "ts-node -r tsconfig-paths/register src/main.ts",
-    "start:dev": "dotenv -e ../.env -- concurrently --handle-input \"wait-on dist/main.js && nodemon\" \"tsc -w -p tsconfig.build.json\" ",
+    "start:dev": "dotenv -e .env -- concurrently --handle-input \"wait-on dist/main.js && nodemon\" \"tsc -w -p tsconfig.build.json\" ",
     "start:debug": "nodemon --config nodemon-debug.json",
     "prestart:prod": "rimraf dist && npm run build",
     "start:prod": "node dist/main.js",

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,0 +1,6 @@
+### Listening port
+SERVER_PORT=3000
+
+
+### Authentication
+JWT_SECRET=some_secret_from_journal

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,6 +1,0 @@
-### Listening port
-SERVER_PORT=3000
-
-
-### Authentication
-JWT_SECRET=some_secret_from_journal

--- a/src/docs/configuration.md
+++ b/src/docs/configuration.md
@@ -1,0 +1,9 @@
+# Configuration
+
+The dotenv library is used to load the .env file
+
+### Listening Port
+* `SERVER_PORT`: sets the port number that the server listens to.
+
+### JWT Secret
+* `JWT_SECRET`: secret used to sign jwt tokens

--- a/src/docs/configuration.md
+++ b/src/docs/configuration.md
@@ -7,3 +7,13 @@ The dotenv library is used to load the .env file
 
 ### JWT Secret
 * `JWT_SECRET`: secret used to sign jwt tokens
+
+### New Relic
+
+For more info, see the [New Relic](https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration) documentation
+
+* `NEW_RELIC_ENABLED`: By default new relic is disabled. Set this to true to turn on the New Relic agent on the server.
+* `NEW_RELIC_LICENSE_KEY`: Server agent license key
+* `NEW_RELIC_APP_NAME`: Server agent app name
+* `NEW_RELIC_NO_CONFIG_FILE`: Whether to disable config file (should be always true)
+* `NEW_RELIC_LOG_LEVEL`: Info level

--- a/src/docs/developing.md
+++ b/src/docs/developing.md
@@ -14,12 +14,6 @@ This should get you started with a [default configuration](../.env.example) that
 
 ### Server
 
-Start the database service
-
-```
-docker-compose up -d postgres
-```
-
 To start the server, run
 ```
 cd server/

--- a/src/docs/developing.md
+++ b/src/docs/developing.md
@@ -1,0 +1,27 @@
+# Developing
+
+## Basic Configuration
+
+Copy the example .env file
+
+```
+cp .env.example .env
+```
+
+This should get you started with a [default configuration](../.env.example) that works out of the box. Refer to the
+[Configuration documentation](./configuration.md) for a more detailed description.
+
+
+### Server
+
+Start the database service
+```
+docker-compose up -d postgres
+```
+
+To start the server, run
+```
+cd server/
+yarn
+yarn run start:dev
+```

--- a/src/docs/developing.md
+++ b/src/docs/developing.md
@@ -15,6 +15,7 @@ This should get you started with a [default configuration](../.env.example) that
 ### Server
 
 Start the database service
+
 ```
 docker-compose up -d postgres
 ```


### PR DESCRIPTION
Migrate relevant documentation across from reviewer. Add a `.env` file so that `yarn start:dev` doesn't throw errors.

__I've not tested the application works, just that no errors are thrown when following the development docs. We need to do a pass on this__