### PR TITLE
Fixed wrong configuration path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,10 @@ services:
       retries: 3
     command: ["bash", "-c", "yarn && yarn run start:dev"]
     environment:
-      NEW_RELIC_HOME: ${NEW_RELIC_HOME:-/config}
+      NEW_RELIC_HOME: ${NEW_RELIC_HOME:-/etc/reviewer/}
     volumes:
       - ./:/src/:z
-      - ./config/:/config/:z
+      - ./config/:/etc/reviewer/:z
     networks:
       - "infra_api"
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig.build.json",
     "format": "prettier --write \"src/**/*.ts\"",
     "start": "ts-node -r tsconfig-paths/register src/main.ts",
-    "start:dev": "NEW_RELIC_HOME=config/ concurrently --handle-input \"wait-on dist/main.js && nodemon\" \"tsc -w -p tsconfig.build.json\" ",
+    "start:dev": "NEW_RELIC_HOME=config/ CONFIG_PATH=config/config.json concurrently --handle-input \"wait-on dist/main.js && nodemon\" \"tsc -w -p tsconfig.build.json\" ",
     "start:debug": "nodemon --config nodemon-debug.json",
     "prestart:prod": "rimraf dist && npm run build",
     "start:prod": "node dist/main.js",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,7 +6,8 @@ import { ConfigModule } from './modules/config/config.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { SubmissionModule } from './modules/submission-adaptor/submission.module';
 import { PassportModule } from '@nestjs/passport';
-import { resolve } from 'path';
+
+const configPath = process.env.CONFIG_PATH ? process.env.CONFIG_PATH : '/config/config.json';
 
 @Module({
     controllers: [AppController],
@@ -16,7 +17,7 @@ import { resolve } from 'path';
             context: ({ req }) => ({ req }),
             typePaths: ['**/modules/**/*.graphql'],
         }),
-        ConfigModule.load(resolve(__dirname, '..', 'config', 'config.json')),
+        ConfigModule.load(configPath),
         AuthModule,
         SubmissionModule,
     ],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,7 +7,7 @@ import { AuthModule } from './modules/auth/auth.module';
 import { SubmissionModule } from './modules/submission-adaptor/submission.module';
 import { PassportModule } from '@nestjs/passport';
 
-const configPath = process.env.CONFIG_PATH ? process.env.CONFIG_PATH : '/config/config.json';
+const configPath = process.env.CONFIG_PATH ? process.env.CONFIG_PATH : '/etc/reviewer/config.json';
 
 @Module({
     controllers: [AppController],


### PR DESCRIPTION
Closes #16:

Adds use of a CONFIG_PATH env var with default to set config file location. This defaults to /config/config.json but is overridden in local development in start:dev command