### PR TITLE
33 - article type & xpub schema compliance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,9 @@ test: get_deps
 
 test_integration:
 	${DOCKER_COMPOSE_TEST} down
-	${DOCKER_COMPOSE_TEST} up -d
+	${DOCKER_COMPOSE_TEST} up -d postgres
 	./.scripts/docker/wait-healthy.sh test_postgres 20
+	${DOCKER_COMPOSE_TEST} up -d application
 	./.scripts/docker/wait-healthy.sh test_reviewer-submission 20
 	yarn run test:integration
 	${DOCKER_COMPOSE_TEST} down

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ test: get_deps
 test_integration:
 	${DOCKER_COMPOSE_TEST} down
 	${DOCKER_COMPOSE_TEST} up -d
+	./.scripts/docker/wait-healthy.sh test_postgres 20
 	./.scripts/docker/wait-healthy.sh test_reviewer-submission 20
 	yarn run test:integration
 	${DOCKER_COMPOSE_TEST} down

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,3 +17,13 @@ services:
       interval: 3s
       timeout: 10s
       retries: 3
+  postgres:
+    image: liberoadmin/reviewer-xpub-postgres:latest
+    container_name: test_postgres
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 30s
+      retries: 10

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "prestart:prod": "rimraf dist && npm run build",
         "start:prod": "node dist/main.js",
         "lint": "eslint --ext .js,.ts src/",
+        "prettier": "prettier --write './src/**/*.ts'",
         "test": "NEW_RELIC_NO_CONFIG_FILE=true jest ./src",
         "test:watch": "NEW_RELIC_NO_CONFIG_FILE=true jest ./src --watch",
         "test:cov": "NEW_RELIC_NO_CONFIG_FILE=true jest ./src --coverage",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "test:watch": "NEW_RELIC_NO_CONFIG_FILE=true jest ./src --watch",
         "test:cov": "NEW_RELIC_NO_CONFIG_FILE=true jest ./src --coverage",
         "test:debug": "NEW_RELIC_NO_CONFIG_FILE=true node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest .src/ --runInBand",
-        "test:integration": "jest ./tests/",
+        "test:integration": "CONFIG_PATH=tests/config/reviewer-submission.json jest ./tests/",
         "update:internal": "yarn upgrade -P @libero"
     },
     "repository": {

--- a/src/entities/submission.test.ts
+++ b/src/entities/submission.test.ts
@@ -8,6 +8,8 @@ describe('Submission Entity', () => {
         const submission = new SubmissionEntity({
             id: id,
             title: '',
+            status: 'INITIAL',
+            createdBy: '123',
             updated: new Date(),
             articleType: '',
         });

--- a/src/entities/submission.ts
+++ b/src/entities/submission.ts
@@ -36,7 +36,7 @@ export class SubmissionMapper {
             updated: sub.updated,
             meta: {
                 articleType: sub.articleType,
-            }
+            },
         };
     }
     public static toViewDto(sub: Submission): DtoViewSubmission {
@@ -48,9 +48,9 @@ export class SubmissionMapper {
         };
     }
     public static fromDto(sub: DtoSubmission): SubmissionEntity {
-        const mappedSubmissionDto: Submission = { 
+        const mappedSubmissionDto: Submission = {
             ...sub,
-            articleType: SubmissionMapper.getMetaValue(sub, 'articleType')
+            articleType: SubmissionMapper.getMetaValue(sub, 'articleType'),
         };
         return new SubmissionEntity(mappedSubmissionDto);
     }
@@ -58,7 +58,7 @@ export class SubmissionMapper {
     static getMetaValue(sub: DtoSubmission, metaProperty: string): string {
         try {
             return (sub.meta as { [key: string]: string })[metaProperty];
-        }catch(_) {
+        } catch (_) {
             throw new Error(`Unable to find property ${metaProperty} on DtoSubmission`);
         }
     }

--- a/src/entities/submission.ts
+++ b/src/entities/submission.ts
@@ -34,7 +34,9 @@ export class SubmissionMapper {
             id: sub.id,
             title: sub.title,
             updated: sub.updated,
-            articleType: sub.articleType,
+            meta: {
+                articleType: sub.articleType,
+            }
         };
     }
     public static toViewDto(sub: Submission): DtoViewSubmission {
@@ -46,6 +48,18 @@ export class SubmissionMapper {
         };
     }
     public static fromDto(sub: DtoSubmission): SubmissionEntity {
-        return new SubmissionEntity(sub);
+        const mappedSubmissionDto: Submission = { 
+            ...sub,
+            articleType: SubmissionMapper.getMetaValue(sub, 'articleType')
+        };
+        return new SubmissionEntity(mappedSubmissionDto);
+    }
+
+    static getMetaValue(sub: DtoSubmission, metaProperty: string): string {
+        try {
+            return (sub.meta as { [key: string]: string })[metaProperty];
+        }catch(_) {
+            throw new Error(`Unable to find property ${metaProperty} on DtoSubmission`);
+        }
     }
 }

--- a/src/repositories/submission.ts
+++ b/src/repositories/submission.ts
@@ -4,7 +4,7 @@ import { InfraLogger as logger } from '../logger';
 import { SubmissionMapper } from '../entities/submission';
 
 export class KnexSubmissionRepository implements SubmissionRepository {
-    private readonly TABLE_NAME = 'submission';
+    private readonly TABLE_NAME = 'manuscript';
     // private readonly logger = new Logger(KnexSubmissionRepository.name);
 
     public constructor(private readonly knex: Knex<{}, unknown[]>) {}
@@ -23,8 +23,9 @@ export class KnexSubmissionRepository implements SubmissionRepository {
             .withSchema('public')
             .createTable(this.TABLE_NAME, (table: Knex.CreateTableBuilder) => {
                 table.uuid('id');
-                table.string('title');
                 table.timestamp('updated').defaultTo(this.knex.fn.now());
+                table.string('status');
+                table.string('created_by');
                 table.jsonb('meta');
                 logger.info(`created table ${this.TABLE_NAME}`);
             });
@@ -38,7 +39,7 @@ export class KnexSubmissionRepository implements SubmissionRepository {
     public async findAll(): Promise<Submission[]> {
         const result = await this.knex
             .withSchema('public')
-            .select<DtoSubmission[]>('id', 'title', 'updated', 'meta')
+            .select<DtoSubmission[]>('id', 'updated', 'created_by', 'status', 'meta')
             .from(this.TABLE_NAME);
         return result.map(SubmissionMapper.fromDto);
     }
@@ -46,7 +47,7 @@ export class KnexSubmissionRepository implements SubmissionRepository {
     public async findById(id: SubmissionId): Promise<Submission | null> {
         const rows = await this.knex
             .withSchema('public')
-            .select<DtoSubmission[]>('id', 'title', 'updated', 'meta')
+            .select<DtoSubmission[]>('id', 'updated', 'created_by', 'status', 'meta')
             .from(this.TABLE_NAME)
             .where({ id });
 

--- a/src/repositories/submission.ts
+++ b/src/repositories/submission.ts
@@ -4,7 +4,7 @@ import { InfraLogger as logger } from '../logger';
 import { SubmissionMapper } from '../entities/submission';
 
 export class KnexSubmissionRepository implements SubmissionRepository {
-    private readonly TABLE_NAME = 'manuscript';
+    private readonly TABLE_NAME = 'submission';
     // private readonly logger = new Logger(KnexSubmissionRepository.name);
 
     public constructor(private readonly knex: Knex<{}, unknown[]>) {}
@@ -13,19 +13,21 @@ export class KnexSubmissionRepository implements SubmissionRepository {
         // TODO: Add a method for handling when the table does/doesn't exist
         // as this will error if the table already exists
         // XXX: Maybe move this to migrations
-        const hasTable = await this.knex.schema.hasTable(this.TABLE_NAME);
+        const hasTable = await this.knex.schema.withSchema('public').hasTable(this.TABLE_NAME);
 
         if (hasTable) {
             return hasTable;
         }
 
-        return await this.knex.schema.createTable(this.TABLE_NAME, (table: Knex.CreateTableBuilder) => {
-            table.uuid('id');
-            table.string('title');
-            table.timestamp('updated').defaultTo(this.knex.fn.now());
-            table.jsonb('meta');
-            logger.log(`created table ${this.TABLE_NAME}`);
-        });
+        return await this.knex.schema
+            .withSchema('public')
+            .createTable(this.TABLE_NAME, (table: Knex.CreateTableBuilder) => {
+                table.uuid('id');
+                table.string('title');
+                table.timestamp('updated').defaultTo(this.knex.fn.now());
+                table.jsonb('meta');
+                logger.log(`created table ${this.TABLE_NAME}`);
+            });
     }
 
     close(): void {
@@ -34,14 +36,19 @@ export class KnexSubmissionRepository implements SubmissionRepository {
     }
 
     public async findAll(): Promise<Submission[]> {
-        const result = await this.knex(this.TABLE_NAME).select<DtoSubmission[]>('id', 'title', 'updated', 'meta');
+        const result = await this.knex
+            .withSchema('public')
+            .select<DtoSubmission[]>('id', 'title', 'updated', 'meta')
+            .from(this.TABLE_NAME);
         return result.map(SubmissionMapper.fromDto);
     }
 
     public async findById(id: SubmissionId): Promise<Submission | null> {
-        const rows = await this.knex(this.TABLE_NAME)
-            .where({ id })
-            .select<DtoSubmission[]>('id', 'title', 'updated', 'meta');
+        const rows = await this.knex
+            .withSchema('public')
+            .select<DtoSubmission[]>('id', 'title', 'updated', 'meta')
+            .from(this.TABLE_NAME)
+            .where({ id });
 
         return rows.length > 0 ? SubmissionMapper.fromDto(rows[0]) : null;
     }
@@ -49,14 +56,19 @@ export class KnexSubmissionRepository implements SubmissionRepository {
     public async save(sub: Submission): Promise<Submission | null> {
         const dtoSubmission: DtoSubmission = SubmissionMapper.toDto(sub);
         dtoSubmission.updated = new Date();
-        await this.knex(this.TABLE_NAME)
+        await this.knex
+            .withSchema('public')
             .insert(dtoSubmission)
+            .into(this.TABLE_NAME)
             .returning('id');
+
         return SubmissionMapper.fromDto(dtoSubmission);
     }
 
     public async delete(id: SubmissionId): Promise<boolean> {
-        const res = await this.knex(this.TABLE_NAME)
+        const res = await this.knex
+            .withSchema('public')
+            .from(this.TABLE_NAME)
             .where({ id })
             .delete();
         return res >= 1 ? true : false;

--- a/src/repositories/submission.ts
+++ b/src/repositories/submission.ts
@@ -26,7 +26,7 @@ export class KnexSubmissionRepository implements SubmissionRepository {
                 table.string('title');
                 table.timestamp('updated').defaultTo(this.knex.fn.now());
                 table.jsonb('meta');
-                logger.log(`created table ${this.TABLE_NAME}`);
+                logger.info(`created table ${this.TABLE_NAME}`);
             });
     }
 

--- a/src/repositories/submission.ts
+++ b/src/repositories/submission.ts
@@ -23,6 +23,7 @@ export class KnexSubmissionRepository implements SubmissionRepository {
             table.uuid('id');
             table.string('title');
             table.timestamp('updated').defaultTo(this.knex.fn.now());
+            table.jsonb('meta');
             logger.log(`created table ${this.TABLE_NAME}`);
         });
     }
@@ -33,14 +34,14 @@ export class KnexSubmissionRepository implements SubmissionRepository {
     }
 
     public async findAll(): Promise<Submission[]> {
-        const result = await this.knex(this.TABLE_NAME).select<DtoSubmission[]>('id', 'title', 'updated');
+        const result = await this.knex(this.TABLE_NAME).select<DtoSubmission[]>('id', 'title', 'updated', 'meta');
         return result.map(SubmissionMapper.fromDto);
     }
 
     public async findById(id: SubmissionId): Promise<Submission | null> {
         const rows = await this.knex(this.TABLE_NAME)
             .where({ id })
-            .select<DtoSubmission[]>('id', 'title', 'updated');
+            .select<DtoSubmission[]>('id', 'title', 'updated', 'meta');
 
         return rows.length > 0 ? SubmissionMapper.fromDto(rows[0]) : null;
     }

--- a/src/repositories/submission.ts
+++ b/src/repositories/submission.ts
@@ -4,7 +4,7 @@ import { InfraLogger as logger } from '../logger';
 import { SubmissionMapper } from '../entities/submission';
 
 export class KnexSubmissionRepository implements SubmissionRepository {
-    private readonly TABLE_NAME = 'submission';
+    private readonly TABLE_NAME = 'manuscript';
     // private readonly logger = new Logger(KnexSubmissionRepository.name);
 
     public constructor(private readonly knex: Knex<{}, unknown[]>) {}

--- a/src/resolvers/submission.ts
+++ b/src/resolvers/submission.ts
@@ -2,6 +2,8 @@ import { SubmissionService } from '../services/submission';
 import { SubmissionId, DtoViewSubmission } from '../types/submission';
 import { IResolvers } from 'apollo-server-express';
 
+const articlesTypes = ['researchArticle', 'featureArticle', 'researchAdvance'];
+
 const resolvers = (submissionService: SubmissionService): IResolvers => ({
     Query: {
         async getSubmissions(): Promise<DtoViewSubmission[] | null> {
@@ -13,6 +15,9 @@ const resolvers = (submissionService: SubmissionService): IResolvers => ({
     },
     Mutation: {
         async startSubmission(_, args: { articleType: string }): Promise<DtoViewSubmission | null> {
+            if (!articlesTypes.includes(args.articleType)) {
+                throw new Error('Invalid article type');
+            }
             return await submissionService.create(args.articleType);
         },
 

--- a/src/resolvers/submission.ts
+++ b/src/resolvers/submission.ts
@@ -2,8 +2,6 @@ import { SubmissionService } from '../services/submission';
 import { SubmissionId, DtoViewSubmission } from '../types/submission';
 import { IResolvers } from 'apollo-server-express';
 
-const articlesTypes = ['researchArticle', 'featureArticle', 'researchAdvance'];
-
 const resolvers = (submissionService: SubmissionService): IResolvers => ({
     Query: {
         async getSubmissions(): Promise<DtoViewSubmission[] | null> {
@@ -15,9 +13,6 @@ const resolvers = (submissionService: SubmissionService): IResolvers => ({
     },
     Mutation: {
         async startSubmission(_, args: { articleType: string }): Promise<DtoViewSubmission | null> {
-            if (!articlesTypes.includes(args.articleType)) {
-                throw new Error('Invalid article type');
-            }
             return await submissionService.create(args.articleType);
         },
 

--- a/src/resolvers/submission.ts
+++ b/src/resolvers/submission.ts
@@ -12,8 +12,8 @@ const resolvers = (submissionService: SubmissionService): IResolvers => ({
         },
     },
     Mutation: {
-        async startSubmission(_, args: { articleType: string }): Promise<DtoViewSubmission | null> {
-            return await submissionService.create(args.articleType);
+        async startSubmission(_, args: { articleType: string }, context): Promise<DtoViewSubmission | null> {
+            return await submissionService.create(args.articleType, context.userId);
         },
 
         async changeSubmissionTitle(_, args: { id: string; title: string }): Promise<DtoViewSubmission | null> {

--- a/src/services/submission.ts
+++ b/src/services/submission.ts
@@ -16,13 +16,20 @@ export class SubmissionService {
         return await this.submissionRepository.findAll();
     }
 
-    async create(articleType: string): Promise<DtoViewSubmission | null> {
+    async create(articleType: string, userId: string): Promise<DtoViewSubmission | null> {
         if (!SubmissionService.validateArticleType(articleType)) {
             throw new Error('Invalid article type');
         }
 
         const id = SubmissionId.fromUuid(uuid());
-        const submission = new SubmissionEntity({ id, title: '', updated: new Date(), articleType });
+        const submission = new SubmissionEntity({
+            id,
+            title: '',
+            updated: new Date(),
+            articleType,
+            status: 'INITIAL',
+            createdBy: userId,
+        });
         return await this.submissionRepository.save(submission);
     }
 

--- a/src/services/submission.ts
+++ b/src/services/submission.ts
@@ -17,7 +17,7 @@ export class SubmissionService {
 
     async create(articleType: string): Promise<DtoViewSubmission | null> {
         const id = SubmissionId.fromUuid(uuid());
-        const submission = new SubmissionEntity({ id, title: '', updated: new Date(), articleType});
+        const submission = new SubmissionEntity({ id, title: '', updated: new Date(), articleType });
         return await this.submissionRepository.save(submission);
     }
 

--- a/src/services/submission.ts
+++ b/src/services/submission.ts
@@ -9,6 +9,7 @@ export class SubmissionService {
 
     constructor(knexConnection: Knex<{}, unknown[]>) {
         this.submissionRepository = new KnexSubmissionRepository(knexConnection);
+        this.submissionRepository.initSchema();
     }
 
     async findAll(): Promise<DtoViewSubmission[]> {

--- a/src/services/submission.ts
+++ b/src/services/submission.ts
@@ -17,6 +17,10 @@ export class SubmissionService {
     }
 
     async create(articleType: string): Promise<DtoViewSubmission | null> {
+        if (!SubmissionService.validateArticleType(articleType)) {
+            throw new Error('Invalid article type');
+        }
+
         const id = SubmissionId.fromUuid(uuid());
         const submission = new SubmissionEntity({ id, title: '', updated: new Date(), articleType });
         return await this.submissionRepository.save(submission);
@@ -37,5 +41,10 @@ export class SubmissionService {
 
     async delete(id: SubmissionId): Promise<boolean> {
         return await this.submissionRepository.delete(id);
+    }
+
+    static validateArticleType(articleType: string): boolean {
+        const articlesTypes = ['researchArticle', 'featureArticle', 'researchAdvance'];
+        return articlesTypes.includes(articleType);
     }
 }

--- a/src/services/submission.ts
+++ b/src/services/submission.ts
@@ -17,7 +17,7 @@ export class SubmissionService {
 
     async create(articleType: string): Promise<DtoViewSubmission | null> {
         const id = SubmissionId.fromUuid(uuid());
-        const submission = new SubmissionEntity({ id, title: '', updated: new Date(), articleType });
+        const submission = new SubmissionEntity({ id, title: '', updated: new Date(), articleType});
         return await this.submissionRepository.save(submission);
     }
 

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -6,16 +6,20 @@ export interface Submission {
     id: SubmissionId;
     title: string;
     updated: Date;
+    createdBy: string;
+    status: string;
     articleType: string;
 }
 
-type xpubMeta = {
+export type xpubMeta = {
     articleType: string;
+    title: string;
 };
 export interface DtoSubmission {
     id: SubmissionId;
-    title: string;
     updated: Date;
+    created_by: string;
+    status: string;
     meta: xpubMeta;
 }
 

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -10,7 +10,7 @@ export interface Submission {
 }
 
 type xpubMeta = {
-    articleType: string
+    articleType: string;
 };
 export interface DtoSubmission {
     id: SubmissionId;

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -9,11 +9,14 @@ export interface Submission {
     articleType: string;
 }
 
+type xpubMeta = {
+    articleType: string
+};
 export interface DtoSubmission {
     id: SubmissionId;
     title: string;
     updated: Date;
-    articleType: string;
+    meta: xpubMeta;
 }
 
 export interface DtoViewSubmission {

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -46,5 +46,6 @@ describe('App', () => {
         );
         expect(response.status).toBe(200);
         expect(response.data.errors.length).toBeGreaterThan(0);
+        expect(response.data.errors[0].message).toBe('Invalid article type');
     });
 });

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -45,6 +45,7 @@ describe('App', () => {
             { headers: { Authorization: `Bearer ${jwtToken}` } },
         );
         expect(response.status).toBe(200);
+        console.log('response.data', response.data);
         expect(response.data.errors.length).toBeGreaterThan(0);
     });
 });

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -23,7 +23,6 @@ describe('App', () => {
             { headers: { Authorization: `Bearer ${jwtToken}` } },
         );
         expect(response.status).toBe(200);
-        console.log(response.data);
         expect(response.data.data.startSubmission.id).toHaveLength(36);
     });
 
@@ -47,5 +46,27 @@ describe('App', () => {
         expect(response.status).toBe(200);
         expect(response.data.errors.length).toBeGreaterThan(0);
         expect(response.data.errors[0].message).toBe('Invalid article type');
+    });
+
+    it('returns error bad query - no articleType param', async () => {
+        expect.assertions(2);
+        await axios
+            .post(
+                'http://localhost:3000/graphql',
+                {
+                    query: `mutation StartSubmission($articleType: String) {
+                    startSubmission(articleType: $articleType) {
+                        id
+                    }
+                }
+            `,
+                    variables: {},
+                },
+                { headers: { Authorization: `Bearer ${jwtToken}` } },
+            )
+            .catch(e => {
+                expect(e.response.status).toBe(400);
+                expect(e.response.statusText).toBe('Bad Request');
+            });
     });
 });

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,36 +1,49 @@
 import axios from 'axios';
+import { sign } from 'jsonwebtoken';
+import config from '../src/config';
+
+const jwtToken = sign({ sub: '123' }, config.authentication_jwt_secret);
 
 describe('App', () => {
     it('returns no errors on valid research article', async () => {
-        const response = await axios.post('http://localhost:3000/graphql', {
-            query: `
+        const response = await axios.post(
+            'http://localhost:3000/graphql',
+            {
+                query: `
                 mutation StartSubmission($articleType: String!) {
                     startSubmission(articleType: $articleType) {
                         id
                     }
                 }
             `,
-            variables: {
-                articleType: 'researchArticle',
+                variables: {
+                    articleType: 'researchArticle',
+                },
             },
-        });
+            { headers: { Authorization: `Bearer ${jwtToken}` } },
+        );
         expect(response.status).toBe(200);
+        console.log(response.data);
         expect(response.data.data.startSubmission.id).toHaveLength(36);
     });
 
     it('returns error on invalid research article', async () => {
-        const response = await axios.post('http://localhost:3000/graphql', {
-            query: `
+        const response = await axios.post(
+            'http://localhost:3000/graphql',
+            {
+                query: `
                 mutation StartSubmission($articleType: String!) {
                     startSubmission(articleType: $articleType) {
                         id
                     }
                 }
             `,
-            variables: {
-                articleType: 'Invalid Article Type',
+                variables: {
+                    articleType: 'Invalid Article Type',
+                },
             },
-        });
+            { headers: { Authorization: `Bearer ${jwtToken}` } },
+        );
         expect(response.status).toBe(200);
         expect(response.data.errors.length).toBeGreaterThan(0);
     });

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -45,7 +45,6 @@ describe('App', () => {
             { headers: { Authorization: `Bearer ${jwtToken}` } },
         );
         expect(response.status).toBe(200);
-        console.log('response.data', response.data);
         expect(response.data.errors.length).toBeGreaterThan(0);
     });
 });

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -23,6 +23,7 @@ describe('App', () => {
             { headers: { Authorization: `Bearer ${jwtToken}` } },
         );
         expect(response.status).toBe(200);
+        console.log(response.data.errors);
         expect(response.data.data.startSubmission.id).toHaveLength(36);
     });
 

--- a/tests/config/reviewer-submission.json
+++ b/tests/config/reviewer-submission.json
@@ -1,13 +1,13 @@
 {
     "port": 3000,
-    "databases": {
-        "submission": {
-            "type": "sqlite3",
-            "database": "data.db"
-        },
-        "survey": {
-            "type": "sqlite3",
-            "database": "data.db"
+    "knex": {
+        "client": "pg",
+        "connection": {
+            "host": "postgres",
+            "database": "reviewer_submission",
+            "user": "postgres",
+            "password": "postgres",
+            "port": 5432
         }
     },
     "authentication_jwt_secret": "super_secret_jam",

--- a/tests/config/reviewer-submission.json
+++ b/tests/config/reviewer-submission.json
@@ -4,7 +4,7 @@
         "client": "pg",
         "connection": {
             "host": "postgres",
-            "database": "reviewer_submission",
+            "database": "postgres",
             "user": "postgres",
             "password": "postgres",
             "port": 5432

--- a/tests/config/reviewer-submission.json
+++ b/tests/config/reviewer-submission.json
@@ -3,7 +3,7 @@
     "knex": {
         "client": "pg",
         "connection": {
-            "host": "localhost",
+            "host": "postgres",
             "database": "postgres",
             "user": "postgres",
             "password": "postgres",

--- a/tests/config/reviewer-submission.json
+++ b/tests/config/reviewer-submission.json
@@ -3,7 +3,7 @@
     "knex": {
         "client": "pg",
         "connection": {
-            "host": "postgres",
+            "host": "localhost",
             "database": "postgres",
             "user": "postgres",
             "password": "postgres",


### PR DESCRIPTION
Closes #33 

This persists `articleType` to the DB. Carrying out this work identified a number of issues with the repo not lining up with xpub schema. This adds basic level of compliance but we still need to add in the business level validation for things like `status` (should be an enum of strings). 
