### PR TITLE
Fixed getCurrentUser

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,0 @@
-{
-  "watch": ["dist"],
-  "ext": "js",
-  "exec": "node dist/main"
-}

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,12 +86,12 @@ const init = async (): Promise<void> => {
         validationRules: [depthLimit(config.max_ql_depth)],
         // @todo: Introspection queries will be blocked unless you are authenticated.
         // The point to consider - is this expected behaviour or should it allow Introspection regardless of auth status.
-        context: ({ req }: ExpressContext): { userId: string } => {
+        context: ({ req }: ExpressContext): { userId: string; authorizationHeader: string } => {
             try {
                 // @todo: we need to use the correct libero auth token
                 const token = (req.headers.authorization || '').split(' ')[1];
                 const decodedToken = verify(token, config.authentication_jwt_secret) as { sub: string };
-                return { userId: decodedToken.sub };
+                return { userId: decodedToken.sub, authorizationHeader: req.headers.authorization || '' };
             } catch (e) {
                 throw new AuthenticationError('You must be logged in');
             }

--- a/src/schemas/user.graphql
+++ b/src/schemas/user.graphql
@@ -2,6 +2,8 @@ type User {
   id: ID!
   name: String!
   role: String!
+  email: String
+  aff: String
 }
 
 type Query {

--- a/src/user/resolvers/user.ts
+++ b/src/user/resolvers/user.ts
@@ -4,8 +4,8 @@ import { IResolvers } from 'apollo-server-express';
 
 const resolvers = (userService: UserService): IResolvers => ({
     Query: {
-        async getCurrentUser(_, args, context: { authScope: string }): Promise<User> {
-            return await userService.getCurrentUser(context.authScope);
+        async getCurrentUser(_, args, context: { authorizationHeader: string }): Promise<User> {
+            return await userService.getCurrentUser(context.authorizationHeader);
         },
     },
 });


### PR DESCRIPTION
Updated User type schema and fixed context not passing authorization header to resolvers

