### PR TITLE
chore: simplify ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,22 @@
 name: CI
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
     branches:
       - master
+
 env:
   IMAGE_TAG: ${{ github.sha }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
         with:
-          submodules: true
+          submodules: 'true'
       - uses: actions/setup-node@v1
         with:
           node-version: '12.15'
@@ -23,16 +26,18 @@ jobs:
           key: ${{ runner.os }}-yarn-client-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-client-
-      - name: Lint
-        run: make lint
-      - name: Unit Test
-        run: make test
+
+      - name: Lint & Test
+        run: |
+          make lint
+          make test
+
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
         with:
-          submodules: true
+          submodules: 'true'
       - uses: actions/setup-node@v1
         with:
           node-version: '12.15'
@@ -42,30 +47,26 @@ jobs:
           key: ${{ runner.os }}-yarn-client-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-client-
-      - name: Build
+
+      - name: Build and Package Container Images
         run: |
           make build
           make build_xpub_postgres
-      - name: Save Docker images
-        run: |
           mkdir -p docker-image
           docker save -o docker-image/reviewer-submission.tar libero/reviewer-submission:${IMAGE_TAG}
-          gzip docker-image/reviewer-submission.tar
-          mkdir -p docker-xpub-postgres-image
           docker save -o docker-image/reviewer-xpub-postgres.tar libero/reviewer-xpub-postgres:${IMAGE_TAG}
-          gzip docker-image/reviewer-xpub-postgres.tar
-      - name: Upload prod Docker image
-        uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v1
         with:
           name: docker-image
           path: docker-image
-  integration-test:
+
+  integration-tests-and-push:
     needs: [test, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
         with:
-          submodules: true
+          submodules: 'true'
       - uses: actions/setup-node@v1
         with:
           node-version: '12.15'
@@ -75,37 +76,19 @@ jobs:
           key: ${{ runner.os }}-yarn-client-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-client-
-      - name: Download Docker image artifact
-        uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v1
         with:
           name: docker-image
-      - name: Load Docker image
+
+      - name: Load Images, Setup Services, Run Integration Tests
         run: |
-          gunzip docker-image/reviewer-submission.tar.gz
           docker load -i docker-image/reviewer-submission.tar
-      - name: Service Setup
-        run: make setup
-      - name: Start services & Integration tests
-        run: make test_integration
-  deploy-image:
-    runs-on: ubuntu-latest
-    needs: integration-test
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          submodules: true
-      - name: Download Docker image artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: docker-image
-      - name: Load Docker image
-        run: |
-          gunzip docker-image/reviewer-submission.tar.gz
-          docker load -i docker-image/reviewer-submission.tar
-          gunzip docker-image/reviewer-xpub-postgres.tar.gz
           docker load -i docker-image/reviewer-xpub-postgres.tar
-      - name: Push image
+          make setup
+          make test_integration
+
+      - name: Push Images if master or v-tag
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
         run: |
           .scripts/github/push-image.sh reviewer-submission
           .scripts/github/push-image.sh reviewer-xpub-postgres


### PR DESCRIPTION
- only use separate jobs for parallelization
- combine core action into single `run` for easier reading

I felt with made things more legible. Curious as to your thoughts on this.