### PR TITLE
remove title from top level Submission typeDef

### DIFF
--- a/src/schemas/submission.graphql
+++ b/src/schemas/submission.graphql
@@ -2,7 +2,6 @@ scalar Upload
 
 type Submission {
     id: ID!
-    title: String!
     updated: String!
     articleType: String!
     author: AuthorDetails!


### PR DESCRIPTION
This has now been placed in manuscriptDetails property so not needed at top level.