### PR TITLE
Pin base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG image_tag=latest
 
-FROM node:lts-slim@sha256:13feae32c9b554584a6df818bde1546edee7a8e497b54c57680c621235a48606 as source
+FROM node:12-alpine@sha256:5646d1e5bc470500414feb3540186c02845db0e0e1788621c271fbf3a0c1830d
 MAINTAINER eLife Reviewer Product Team <reviewer-product@elifesciences.org>
 
 WORKDIR /app
@@ -18,7 +18,7 @@ COPY src/ ./src/
 RUN yarn &&\
     yarn build
 
-FROM node:lts-slim@sha256:13feae32c9b554584a6df818bde1546edee7a8e497b54c57680c621235a48606
+FROM node:12-alpine@sha256:5646d1e5bc470500414feb3540186c02845db0e0e1788621c271fbf3a0c1830d
 MAINTAINER eLife Reviewer Product Team <reviewer-product@elifesciences.org>
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 ARG image_tag=latest
 
-FROM node:12-alpine@sha256:5646d1e5bc470500414feb3540186c02845db0e0e1788621c271fbf3a0c1830d
+FROM node:12-slim@sha256:13feae32c9b554584a6df818bde1546edee7a8e497b54c57680c621235a48606 as source
 MAINTAINER eLife Reviewer Product Team <reviewer-product@elifesciences.org>
 
 WORKDIR /app
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    python3 \
+    bzip2
 
 COPY  tsconfig.build.json \
       tsconfig.json \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG image_tag=latest
 
-FROM node:12.15 as source
+FROM node:lts-slim@sha256:13feae32c9b554584a6df818bde1546edee7a8e497b54c57680c621235a48606 as source
 MAINTAINER eLife Reviewer Product Team <reviewer-product@elifesciences.org>
 
 WORKDIR /app
@@ -18,7 +18,7 @@ COPY src/ ./src/
 RUN yarn &&\
     yarn build
 
-FROM node:12.15-alpine
+FROM node:lts-slim@sha256:13feae32c9b554584a6df818bde1546edee7a8e497b54c57680c621235a48606
 MAINTAINER eLife Reviewer Product Team <reviewer-product@elifesciences.org>
 
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   application:
-    image: node:10
+    image: node:12-alpine@sha256:5646d1e5bc470500414feb3540186c02845db0e0e1788621c271fbf3a0c1830d
     ports:
       - "${SERVER_PORT:-3000}:3000"
     working_dir: "/src"

--- a/xpub-postgres.Dockerfile
+++ b/xpub-postgres.Dockerfile
@@ -1,3 +1,3 @@
-FROM postgres:11
+FROM postgres:11-alpine@sha256:785334846c220affdc714ecf06fab5006c96dbe2cef6ecd9860f21f330b5caeb
 
 COPY ./xpub-schema.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
- node to 12-alpine/12-slim
- postgres to 11-alpine

- I can't determine what the `docker-compose.yml` is used for, but pinned its node anyway.
- Using slim requires install of python, build-essential and bzip2 in the builder container.  
  This is minimally faster in the pipeline (ca. 10s) but maybe an improvement for devs on sloggish internet (300 vs 50 mb).