### PR TITLE
756 - Failed file upload re-throws error

### DIFF
--- a/src/application/wizard/service.test.ts
+++ b/src/application/wizard/service.test.ts
@@ -1,3 +1,5 @@
+import { FileUpload } from 'graphql-upload';
+import { PubSub } from 'apollo-server-express';
 import { WizardService } from './service';
 import { SubmissionService } from '../../domain/submission';
 import { TeamService } from '../../domain/teams/services/team-service';
@@ -251,5 +253,65 @@ describe('saveAuthorPage', () => {
                 aff: 'aff',
             }),
         ).rejects.toThrow();
+    });
+});
+
+describe('saveManuscript', () => {
+    const mockUser = {
+        id: '89e0aec8-b9fc-4413-8a37-cccccccc',
+        name: 'Bob',
+        role: 'user',
+    };
+    it('should throw if user is not allowed to update submission', async (): Promise<void> => {
+        const permissionService = ({
+            userCanWithSubmission: jest.fn(() => false),
+        } as unknown) as PermissionService;
+
+        const wizardService = new WizardService(
+            permissionService,
+            ({ get: jest.fn(() => Promise.resolve()) } as unknown) as SubmissionService,
+            (jest.fn() as unknown) as TeamService,
+            (jest.fn() as unknown) as FileService,
+            (jest.fn() as unknown) as SemanticExtractionService,
+        );
+        await expect(
+            wizardService.saveManuscriptFile(
+                mockUser,
+                SubmissionId.fromUuid('89e0aec8-b9fc-4413-8a37-5cc775edbe3a'),
+                (jest.fn() as unknown) as FileUpload,
+                0,
+                (jest.fn() as unknown) as PubSub,
+            ),
+        ).rejects.toThrow('User not allowed to save submission');
+    });
+});
+
+describe('saveSupporting', () => {
+    const mockUser = {
+        id: '89e0aec8-b9fc-4413-8a37-cccccccc',
+        name: 'Bob',
+        role: 'user',
+    };
+    it('should throw if user is not allowed to update submission', async (): Promise<void> => {
+        const permissionService = ({
+            userCanWithSubmission: jest.fn(() => false),
+        } as unknown) as PermissionService;
+
+        const wizardService = new WizardService(
+            permissionService,
+            ({ get: jest.fn(() => Promise.resolve()) } as unknown) as SubmissionService,
+            (jest.fn() as unknown) as TeamService,
+            (jest.fn() as unknown) as FileService,
+            (jest.fn() as unknown) as SemanticExtractionService,
+        );
+        await expect(
+            wizardService.saveSupportingFile(
+                mockUser,
+                SubmissionId.fromUuid('89e0aec8-b9fc-4413-8a37-5cc775edbe3a'),
+                (jest.fn() as unknown) as FileUpload,
+                0,
+                (jest.fn() as unknown) as PubSub,
+            ),
+        ).rejects.toThrow('User not allowed to save submission');
     });
 });

--- a/src/application/wizard/service.ts
+++ b/src/application/wizard/service.ts
@@ -97,7 +97,6 @@ export class WizardService {
         if (!allowed) {
             throw new Error('User not allowed to save submission');
         }
-        console.log(fileSize, this.config.max_file_size_in_bytes);
         if (fileSize > this.config.max_file_size_in_bytes) {
             throw new Error(`File truncated as it exceeds the ${this.config.max_file_size_in_bytes} byte size limit.`);
         }

--- a/src/application/wizard/service.ts
+++ b/src/application/wizard/service.ts
@@ -10,7 +10,7 @@ import { PermissionService, SubmissionOperation } from '../permission/service';
 import { User } from 'src/domain/user/user';
 import { FileType, FileId } from '../../domain/file/types';
 import { PubSub } from 'apollo-server-express';
-import config from '../../config';
+import { Config } from '../../config';
 import { InfraLogger as logger } from '../../logger';
 
 export class WizardService {
@@ -20,6 +20,7 @@ export class WizardService {
         private readonly teamService: TeamService,
         private readonly fileService: FileService,
         private readonly semanticExtractionService: SemanticExtractionService,
+        private readonly config: Config,
     ) {}
 
     async getSubmission(user: User, submissionId: SubmissionId): Promise<Submission | null> {
@@ -96,8 +97,9 @@ export class WizardService {
         if (!allowed) {
             throw new Error('User not allowed to save submission');
         }
-        if (fileSize > config.max_file_size_in_bytes) {
-            throw new Error(`File truncated as it exceeds the ${config.max_file_size_in_bytes} byte size limit.`);
+        console.log(fileSize, this.config.max_file_size_in_bytes);
+        if (fileSize > this.config.max_file_size_in_bytes) {
+            throw new Error(`File truncated as it exceeds the ${this.config.max_file_size_in_bytes} byte size limit.`);
         }
         const { filename, mimetype: mimeType, createReadStream } = await file;
         const stream = createReadStream();
@@ -143,8 +145,8 @@ export class WizardService {
         if (!allowed) {
             throw new Error('User not allowed to save submission');
         }
-        if (fileSize > config.max_file_size_in_bytes) {
-            throw new Error(`File truncated as it exceeds the ${config.max_file_size_in_bytes} byte size limit.`);
+        if (fileSize > this.config.max_file_size_in_bytes) {
+            throw new Error(`File truncated as it exceeds the ${this.config.max_file_size_in_bytes} byte size limit.`);
         }
         const { filename, mimetype: mimeType, createReadStream } = await file;
         const stream = createReadStream();

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,7 +66,7 @@ const init = async (): Promise<void> => {
     // init application services
     const srvPermission = new PermissionService();
     const srvDashboard = new DashboardService(srvPermission, srvSubmission);
-    const srvWizard = new WizardService(srvPermission, srvSubmission, srvTeam, srvFile, srvExtractionService);
+    const srvWizard = new WizardService(srvPermission, srvSubmission, srvTeam, srvFile, srvExtractionService, config);
 
     // init resolvers
     const resolvers = [


### PR DESCRIPTION
Closes libero/reviewer#756

- makes config injectable into the WizardService
- adds some basic permission unit tests for supporting and manuscript upload. Coverage is lacking for these functions so will raise another issue to bolster tests.
- throws client friendly error if upload fails