### PR TITLE
1162 block autosave after submission

### DIFF
--- a/src/application/dashboard/service.test.ts
+++ b/src/application/dashboard/service.test.ts
@@ -18,15 +18,16 @@ describe('dashboard service', () => {
         userCanWithSubmission: jest.fn(),
     };
 
-    const submissionService = ({
-        create: jest.fn(),
-        findByUserId: jest.fn(),
-        get: jest.fn(),
-        delete: jest.fn(),
-    } as unknown) as SubmissionService;
+    let submissionService: SubmissionService;
 
     beforeEach(() => {
         jest.resetAllMocks();
+        submissionService = ({
+            create: jest.fn(),
+            findByUserId: jest.fn(async () => []),
+            get: jest.fn(),
+            delete: jest.fn(),
+        } as unknown) as SubmissionService;
     });
 
     describe('findMySubmissions', () => {

--- a/src/application/dashboard/service.test.ts
+++ b/src/application/dashboard/service.test.ts
@@ -44,6 +44,33 @@ describe('dashboard service', () => {
             expect(permissionService.userCan).toHaveBeenCalledTimes(0);
             expect(permissionService.userCanWithSubmission).toHaveBeenCalledTimes(0);
         });
+
+        it('should map the status correctly', async () => {
+            submissionService = ({
+                findByUserId: jest.fn(async () => [
+                    { status: 'INITIAL' },
+                    { status: 'MECA_IMPORT_FAILED' },
+                    { status: 'MECA_EXPORT_FAILED' },
+                    { status: 'MECA_EXPORT_SUCCEEDED' },
+                    { status: 'MECA_EXPORT_PENDING' },
+                    { status: 'not a status' },
+                ]),
+            } as unknown) as SubmissionService;
+            const service = new DashboardService(permissionService, submissionService);
+            const subs = await service.findMySubmissions(mockUser);
+            const subStatuses = subs.map(sub => sub.status);
+            expect(permissionService.isStaff).toHaveBeenCalledTimes(0);
+            expect(permissionService.userCan).toHaveBeenCalledTimes(0);
+            expect(permissionService.userCanWithSubmission).toHaveBeenCalledTimes(0);
+            expect(subStatuses).toStrictEqual([
+                'CONTINUE_SUBMISSION',
+                'SUBMITTED',
+                'SUBMITTED',
+                'SUBMITTED',
+                'SUBMITTED',
+                'CONTINUE_SUBMISSION',
+            ]);
+        });
     });
 
     describe('startSubmission', () => {

--- a/src/application/permission/service.test.ts
+++ b/src/application/permission/service.test.ts
@@ -49,19 +49,19 @@ describe('userCan', () => {
                 const op = SubmissionOperation.UPDATE;
                 user.role = 'user';
                 user.id = 'user-id';
-                const subClone = {...submission};
+                const subClone = { ...submission };
                 subClone.status = 'MECA_EXPORT_PENDING';
                 expect(permission.userCanWithSubmission(user, op, submission)).toBe(true);
-            })
+            });
 
             it('should return true if staff and already submitted', () => {
                 const op = SubmissionOperation.UPDATE;
                 user.role = 'staff';
                 user.id = 'user-id';
-                const subClone = {...submission};
+                const subClone = { ...submission };
                 subClone.status = 'MECA_EXPORT_PENDING';
                 expect(permission.userCanWithSubmission(user, op, submission)).toBe(true);
-            })
+            });
         });
         describe('Any submission', () => {
             it('should return true if staff', () => {

--- a/src/application/permission/service.test.ts
+++ b/src/application/permission/service.test.ts
@@ -19,6 +19,7 @@ describe('userCan', () => {
             status: 'CREATED',
             createdBy: 'user-id',
         });
+        submission.status = 'INITIAL';
     });
 
     describe('SubmissionOperation.UPDATE', () => {

--- a/src/application/permission/service.test.ts
+++ b/src/application/permission/service.test.ts
@@ -44,6 +44,24 @@ describe('userCan', () => {
                 user.id = 'not created by me';
                 expect(permission.userCanWithSubmission(user, op, submission)).toBe(false);
             });
+
+            it('should return false if not staff and already submitted', () => {
+                const op = SubmissionOperation.UPDATE;
+                user.role = 'user';
+                user.id = 'user-id';
+                const subClone = {...submission};
+                subClone.status = 'MECA_EXPORT_PENDING';
+                expect(permission.userCanWithSubmission(user, op, submission)).toBe(true);
+            })
+
+            it('should return true if staff and already submitted', () => {
+                const op = SubmissionOperation.UPDATE;
+                user.role = 'staff';
+                user.id = 'user-id';
+                const subClone = {...submission};
+                subClone.status = 'MECA_EXPORT_PENDING';
+                expect(permission.userCanWithSubmission(user, op, submission)).toBe(true);
+            })
         });
         describe('Any submission', () => {
             it('should return true if staff', () => {

--- a/src/application/permission/service.ts
+++ b/src/application/permission/service.ts
@@ -1,5 +1,6 @@
-import Submission from 'src/domain/submission/services/models/submission';
-import { User } from 'src/domain/user/user';
+import Submission from '../../domain/submission/services/models/submission';
+import { User } from '../../domain/user/user';
+import { SubmissionStatus } from '../../domain/submission/types';
 
 export enum SubmissionOperation {
     CREATE = 'Create Submission',
@@ -33,7 +34,10 @@ export class PermissionService {
             case SubmissionOperation.READ:
             case SubmissionOperation.UPDATE:
             case SubmissionOperation.DELETE:
-                return this.isStaff(user) || submission.createdBy === user.id;
+                return (
+                    this.isStaff(user) ||
+                    (submission.status === SubmissionStatus.INITIAL && submission.createdBy === user.id)
+                );
             default:
                 return false;
         }

--- a/src/application/wizard/service.test.ts
+++ b/src/application/wizard/service.test.ts
@@ -45,6 +45,7 @@ describe('getSubmission', () => {
             id: '89e0aec8-b9fc-4413-8a37-5cc775edbe3a',
             createdBy: '89e0aec8-b9fc-4413-8a37-5cc77567',
             files: {},
+            status: 'INITIAL',
         })),
     } as unknown) as SubmissionService;
 
@@ -140,6 +141,7 @@ describe('saveAuthorPage', () => {
         get: jest.fn().mockImplementation(() => ({
             createdBy: user.id,
             files: {},
+            status: 'INITIAL',
         })),
     } as unknown) as SubmissionService;
 
@@ -217,6 +219,7 @@ describe('saveAuthorPage', () => {
             saveAuthorDetails: jest.fn(),
             get: jest.fn().mockImplementationOnce(() => ({
                 createdBy: user.id,
+                status: 'INITIAL',
             })),
         } as unknown) as SubmissionService;
         const existingTeam = null;
@@ -270,6 +273,7 @@ describe('saveAuthorPage', () => {
         const submissionServiceMock = ({
             get: jest.fn().mockImplementationOnce(() => ({
                 createdBy: '89e0aec8-b9fc-4413-8a37-5cc77567',
+                status: 'INITIAL',
             })),
         } as unknown) as SubmissionService;
 
@@ -348,6 +352,7 @@ describe('saveEditorPage', () => {
             get: jest.fn().mockImplementationOnce(() => ({
                 id: '89e0aec8-b9fc-4413-8a37-5cc775edbe3a',
                 createdBy: '89e0aec8-b9fc-4413-8a37-10Dc77567',
+                status: 'INITIAL',
             })),
         } as unknown) as SubmissionService;
 
@@ -388,6 +393,7 @@ describe('saveEditorPage', () => {
                 id: '89e0aec8-b9fc-4413-8a37-5cc775edbe3a',
                 createdBy: '89e0aec8-b9fc-4413-8a37-5cc77567',
                 files: {},
+                status: 'INITIAL',
             })),
             saveEditorDetails: jest.fn().mockImplementation(() => {}),
         } as unknown) as SubmissionService;
@@ -429,6 +435,7 @@ describe('saveEditorPage', () => {
                 id: '89e0aec8-b9fc-4413-8a37-5cc775edbe3a',
                 createdBy: '89e0aec8-b9fc-4413-8a37-5cc77567',
                 files: {},
+                status: 'INITIAL',
             },
             details.opposedReviewersReason,
             details.opposedReviewingEditorsReason,
@@ -532,6 +539,7 @@ describe('saveDisclosurePage', () => {
                 id: '89e0aec8-b9fc-4413-8a37-5cc775edbe3a',
                 createdBy: '89e0aec8-b9fc-4413-8a37-5cc77567',
                 files: {},
+                status: 'INITIAL',
             })),
             saveDisclosureDetails: jest.fn().mockImplementation(() => {}),
         } as unknown) as SubmissionService;
@@ -564,6 +572,7 @@ describe('saveDisclosurePage', () => {
                 id: '89e0aec8-b9fc-4413-8a37-5cc775edbe3a',
                 createdBy: '89e0aec8-b9fc-4413-8a37-5cc77567',
                 files: {},
+                status: 'INITIAL',
             },
             details,
         );
@@ -578,6 +587,7 @@ describe('submit', () => {
         id: '89e0aec8-b9fc-4413-8a37-5cc775edbe3a',
         createdBy: '89e0aec8-b9fc-4413-8a37-5cc77567',
         files: {},
+        status: 'INITIAL',
     };
     const user = {
         id: '89e0aec8-b9fc-4413-8a37-5cc77567',
@@ -666,6 +676,7 @@ describe('submit', () => {
                 supportingFiles: [],
             },
             id: '89e0aec8-b9fc-4413-8a37-5cc775edbe3a',
+            status: 'CONTINUE_SUBMISSION',
         });
         expect(submitMock.mock.calls[0][1]).toEqual(ip);
         expect(submission).toBeDefined();
@@ -746,6 +757,7 @@ describe('deleteManuscriptFile', () => {
             get: jest.fn().mockImplementationOnce(() => ({
                 id: submissionId,
                 createdBy: '89e0aec8-b9fc-4413-8a37-5cc77567',
+                status: 'INITIAL',
             })),
         } as unknown) as SubmissionService;
 
@@ -1072,6 +1084,7 @@ describe('deleteSupportingFile', () => {
             get: jest.fn().mockImplementationOnce(() => ({
                 id: submissionId,
                 createdBy: '89e0aec8-b9fc-4413-8a37-5cc77567',
+                status: 'INITIAL',
             })),
         } as unknown) as SubmissionService;
 
@@ -1178,6 +1191,7 @@ describe('saveFilesPage', () => {
             id: '89e0aec8-b9fc-4413-8a37-5cc775edbe3a',
             createdBy: '89e0aec8-b9fc-4413-8a37-5cc77567',
             files: {},
+            status: 'INITIAL',
         };
         const submissionServiceMock = ({
             get: jest.fn().mockImplementation(() => sub),
@@ -1289,6 +1303,7 @@ describe('saveDetailsPage', () => {
             id: '89e0aec8-b9fc-4413-8a37-5cc775edbe3a',
             createdBy: '89e0aec8-b9fc-4413-8a37-5cc77567',
             files: {},
+            status: 'INITIAL',
         };
 
         const details = {


### PR DESCRIPTION
Addresses first point from https://github.com/libero/reviewer/issues/1162:

> - wizard is still a form after submission (shouldn't it be read only?)

Also addresses missing status

