### PR TITLE
Add logs similar to xpub (where possible)

### DIFF
--- a/src/domain/file/services/file-service.ts
+++ b/src/domain/file/services/file-service.ts
@@ -129,6 +129,7 @@ export class FileService {
             Key: this.getFileS3Key(FileType.SUPPORTING_FILE, submissionId, fileId),
         });
         await this.setStatusToDeleted(user.id, file);
+        logger.info(`find entry with id: ${fileId} deleted`)
         return fileId;
     }
 
@@ -144,6 +145,7 @@ export class FileService {
             const manuscriptFile = await this.findManuscriptFile(submissionId);
             // we have a file so delete it
             if (manuscriptFile !== null) {
+                logger.info(`replacing existing manuscriptFile with id: ${manuscriptFile.id}`);
                 await this.deleteManuscript(user, manuscriptFile.id, submissionId);
             }
         }
@@ -207,6 +209,7 @@ export class FileService {
     async findManuscriptFile(submissionId: SubmissionId): Promise<File | null> {
         const file = await this.fileRepository.findManuscriptBySubmissionId(submissionId);
         if (!file) {
+            logger.info(`cannot find manuscriptFile with submission id: ${submissionId}`);
             return null;
         }
 
@@ -320,7 +323,7 @@ export class FileService {
             buffer = Buffer.concat(chunks);
             await this.setStatusToStored(userId, file);
         } catch (e) {
-            logger.error(e);
+            logger.error('upload of manuscript file failed', e);
             await this.setStatusToCancelled(userId, file);
         }
 
@@ -338,7 +341,7 @@ export class FileService {
             await this.handleFileUpload(pubsub, submissionId, userId, file, stream, FileType.SUPPORTING_FILE);
             await this.setStatusToStored(userId, file);
         } catch (e) {
-            logger.error(e);
+            logger.error('upload of support file failed', e);
             await this.setStatusToCancelled(userId, file);
             throw e;
         }

--- a/src/domain/mail/services/mail-service.ts
+++ b/src/domain/mail/services/mail-service.ts
@@ -1,5 +1,7 @@
 import * as SES from 'aws-sdk/clients/ses';
 
+import { InfraLogger as logger } from '../../../logger';
+
 export class MailService {
     ses: SES;
     sender: string;
@@ -19,7 +21,9 @@ export class MailService {
         cc: string[] = [],
         bcc: string[] = [],
     ): Promise<boolean> {
+        logger.info('sending email');
         if (this.sendmail === false) {
+            logger.warn('emails are not enabled');
             return false;
         }
 
@@ -48,7 +52,14 @@ export class MailService {
             ReplyToAddresses: [],
             Source: this.sender,
         };
-        await this.ses.sendEmail(params).promise();
-        return true;
+
+        try {
+            await this.ses.sendEmail(params).promise();
+            logger.info('email sent');
+            return true;
+        } catch (e) {
+            logger.error('email failed to send', e);
+            return false;
+        }
     }
 }

--- a/src/domain/semantic-extraction/services/semantic-extraction-service.test.ts
+++ b/src/domain/semantic-extraction/services/semantic-extraction-service.test.ts
@@ -57,7 +57,7 @@ describe('scienceBeamApi', () => {
         const result = await service.extractSuggestions(emptyBuffer, 'application/pdf', 'test.pdf', id);
 
         expect(mockCreate).toBeCalledTimes(1);
-        expect(logger.info).toBeCalledTimes(1);
+        expect(logger.info).toBeCalledTimes(2);
         expect(logger.info).toBeCalledWith('Sciencebeam extracting string');
         expect(result).toBe(true);
     });

--- a/src/domain/semantic-extraction/services/semantic-extraction-service.ts
+++ b/src/domain/semantic-extraction/services/semantic-extraction-service.ts
@@ -73,6 +73,7 @@ export class SemanticExtractionService {
                 timeout,
             });
             if (response.status == 200) {
+                logger.info(`Sciencebeam extracting complete for submission id ${submissionId}`);
                 success = await this.getSuggestionsFromData(submissionId, response.data);
             } else {
                 logger.error(`Sciencebeam responded with: ${response.status} and returned ${response.data}`);

--- a/src/domain/submission/services/exporter/meca-exporter.ts
+++ b/src/domain/submission/services/exporter/meca-exporter.ts
@@ -4,6 +4,7 @@ import Submission from '../models/submission';
 import { encode } from './jwt';
 import { FileService } from '../../../file/services/file-service';
 import { FileId } from '../../../file/types';
+import { InfraLogger as logger } from '../../../../logger';
 import {
     generateArticle,
     generateCoverLetter,
@@ -41,6 +42,7 @@ export class MecaExporter implements SubmissionExporter {
         const token = encode(this.jwtSecret, payload, '15m');
 
         if (!manuscriptFile) {
+            logger.error(`No manuscript found for submission ${submission.id}`);
             throw new Error('No manuscript file');
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -208,6 +208,7 @@ const init = async (): Promise<void> => {
                             estimators,
                         });
                         if (complexity >= config.max_ql_complexity) {
+                            logger.error('Max query complexity reached');
                             throw new UserInputError(
                                 `${complexity} is over max ${config.max_ql_complexity} complexity`,
                             );
@@ -247,6 +248,7 @@ const init = async (): Promise<void> => {
                     };
                     return { userId: decodedToken.sub, authorizationHeader: connectionParams.Authorization };
                 }
+                logger.error('Auth token is missing');
                 throw new Error('Missing auth token!');
             },
         },
@@ -254,8 +256,14 @@ const init = async (): Promise<void> => {
     apolloServer.applyMiddleware({ app });
     const server = app.listen(config.port, () => logger.info(`Service listening on port ${config.port}`));
     apolloServer.installSubscriptionHandlers(server);
-    process.on('SIGTERM', async () => await shutDown(server));
-    process.on('SIGINT', async () => await shutDown(server));
+    process.on('SIGTERM', async () => {
+        logger.info('SIGTERM called');
+        await shutDown(server);
+    });
+    process.on('SIGINT', async () => {
+        logger.info('SIGINT called');
+        await shutDown(server);
+    });
 };
 
 init();


### PR DESCRIPTION
Part of https://github.com/libero/reviewer/issues/1222

Some findings based on xpub searches:

warning logs - https://github.com/elifesciences/elife-xpub/search?q=logger.warn%28&unscoped_q=logger.warn%28 (9 returns) - reviewer has similar logs or better
info logs - https://github.com/elifesciences/elife-xpub/search?q=logger.info%28&unscoped_q=logger.info%28 (14 returns) - reviewer has similar logs or better
error logs - https://github.com/elifesciences/elife-xpub/search?q=logger.error&unscoped_q=logger.error (21 returns) - reviewer has similar logs or better
all logs - https://github.com/elifesciences/elife-xpub/search?q=logger.&unscoped_q=logger. (54 returns) - reviewer has similar logs or better