### PR TITLE
Allow null value for file size due to xpub

### DIFF
--- a/src/domain/submission/services/models/file-schema.ts
+++ b/src/domain/submission/services/models/file-schema.ts
@@ -10,7 +10,7 @@ export const fileSchema = Joi.object({
     filename: Joi.string().required(),
     url: Joi.string().required(),
     mimeType: Joi.string().required(),
-    size: Joi.number().required(),
+    size: Joi.number().required().allow(null), // this allows submissions from xPub to pass validation
     downloadLink: Joi.string(),
     status: Joi.string()
         .required()

--- a/src/domain/submission/services/models/file-schema.ts
+++ b/src/domain/submission/services/models/file-schema.ts
@@ -10,7 +10,9 @@ export const fileSchema = Joi.object({
     filename: Joi.string().required(),
     url: Joi.string().required(),
     mimeType: Joi.string().required(),
-    size: Joi.number().required().allow(null), // this allows submissions from xPub to pass validation
+    size: Joi.number()
+        .required()
+        .allow(null), // this allows submissions from xPub to pass validation
     downloadLink: Joi.string(),
     status: Joi.string()
         .required()


### PR DESCRIPTION
As discussed. Files uploaded on xPub have a size of null where reviewer expects a number. It was agreed that this null value should be allowed through the validation.

Closes https://github.com/libero/reviewer/issues/1413