### PR TITLE
sort fileNames array assertion as order doesn't matter

### DIFF
--- a/tests/wizard.submit.test.ts
+++ b/tests/wizard.submit.test.ts
@@ -37,9 +37,14 @@ const checkArchive = async (content: string): Promise<void> => {
     const contents = await zip.loadAsync(content);
     const fileNames = Object.keys(contents.files);
 
-    expect(fileNames.sort()).toEqual(
-        ['manifest.xml', 'disclosure.pdf', 'a.txt', 'transfer.xml', 'article.xml', 'cover_letter.pdf'].sort(),
-    );
+    expect(fileNames.sort()).toEqual([
+        'a.txt',
+        'article.xml',
+        'cover_letter.pdf',
+        'disclosure.pdf',
+        'manifest.xml',
+        'transfer.xml',
+    ]);
 };
 
 describe('Submit Integration Tests', () => {
@@ -60,9 +65,7 @@ describe('Submit Integration Tests', () => {
         expect(status).toBe('CONTINUE_SUBMISSION');
 
         const submitResponse = await submit(id);
-        expect(submitResponse.data.errors[0].message).toEqual(
-            '"manuscriptDetails.title" is required',
-        );
+        expect(submitResponse.data.errors[0].message).toEqual('"manuscriptDetails.title" is required');
     });
 
     it('exports a meca archive', async () => {

--- a/tests/wizard.submit.test.ts
+++ b/tests/wizard.submit.test.ts
@@ -37,14 +37,9 @@ const checkArchive = async (content: string): Promise<void> => {
     const contents = await zip.loadAsync(content);
     const fileNames = Object.keys(contents.files);
 
-    expect(fileNames).toEqual([
-        'manifest.xml',
-        'disclosure.pdf',
-        'a.txt',
-        'transfer.xml',
-        'article.xml',
-        'cover_letter.pdf',
-    ]);
+    expect(fileNames.sort()).toEqual(
+        ['manifest.xml', 'disclosure.pdf', 'a.txt', 'transfer.xml', 'article.xml', 'cover_letter.pdf'].sort(),
+    );
 };
 
 describe('Submit Integration Tests', () => {


### PR DESCRIPTION
File order in zip isn't guaranteed but also doesn't matter so we should only fail on diffs of file names not order.