### PR TITLE
fix: disclosure pdf test fails the majority of the time

### DIFF
--- a/src/domain/submission/services/exporter/file-generators/disclosure.test.ts
+++ b/src/domain/submission/services/exporter/file-generators/disclosure.test.ts
@@ -2,30 +2,63 @@ import * as PDFParser from 'pdf2json';
 import { generateDisclosure } from './disclosure';
 import submission from './article.test.data';
 
+function toContainChunk(data: Uint8Array[], chunk: Uint8Array[]): boolean {
+    let offset = 0;
+    do {
+        if (data[offset] === chunk[0]) {
+            for (let i = 1; i < chunk.length; i++) {
+                if (data[offset + i] !== chunk[i]) {
+                    break;
+                }
+
+                if (i + 1 === chunk.length) {
+                    return true;
+                }
+            }
+        }
+    } while (++offset < data.length);
+    return false;
+
+    /*
+    const headIndex = data.indexOf(chunk[0]);
+    let pass = headIndex !== -1;
+    if (pass) {
+        for (let i = 1; i < chunk.length; ++i) {
+            if (chunk[i] instanceof RegExp) {
+                pass = pass && chunk[i].test(data[headIndex + i]);
+            } else {
+                pass = pass && this.equals(data[headIndex + i], chunk[i]);
+            }
+        }
+    }
+    return pass;
+    */
+}
+
 describe('Disclosure PDF generator', () => {
     it('returns a string of a PDF', async () => {
         const document = await generateDisclosure(submission, '1.2.3.4');
-        const pdfParser = new PDFParser();
-        let errors = 0;
-        pdfParser.on('pdfParser_dataError', (err: string) => {
-            if (err) errors += 1;
-        });
-        expect.assertions(5);
-        const donePromise = new Promise<boolean>(resolve => {
+
+        const donePromise = new Promise<void>((resolve, reject) => {
+            console.log('PDFParser: construct...');
+            const pdfParser = new PDFParser();
+
+            pdfParser.on('pdfParser_dataError', () => reject);
+
             pdfParser.on('pdfParser_dataReady', () => {
-                expect(errors).toBe(0);
-                expect(pdfParser.data).not.toBe(null);
-
+                /*
                 const jsonData = JSON.stringify(pdfParser.data);
-
+                console.log(jsonData);
                 expect(jsonData.includes('Our%20privacy%20policy')).toBe(true);
                 expect(jsonData.includes('Test%20User')).toBe(true);
                 expect(jsonData.includes('A.Scientist')).toBe(true);
+                */
                 resolve();
             });
+
+            pdfParser.parseBuffer(document).catch(() => reject);
         });
 
-        await pdfParser.parseBuffer(document);
         await donePromise;
     });
 });

--- a/src/domain/submission/services/exporter/file-generators/disclosure.test.ts
+++ b/src/domain/submission/services/exporter/file-generators/disclosure.test.ts
@@ -2,7 +2,7 @@ import * as PDFParser from 'pdf2json';
 import { generateDisclosure } from './disclosure';
 import submission from './article.test.data';
 
-function toContainChunk(data: Uint8Array[], chunk: Uint8Array[]): boolean {
+function toContainChunk(data: Buffer, chunk: Buffer): boolean {
     let offset = 0;
     do {
         if (data[offset] === chunk[0]) {
@@ -16,49 +16,13 @@ function toContainChunk(data: Uint8Array[], chunk: Uint8Array[]): boolean {
                 }
             }
         }
-    } while (++offset < data.length);
+    } while (++offset < data.length - chunk.length);
     return false;
-
-    /*
-    const headIndex = data.indexOf(chunk[0]);
-    let pass = headIndex !== -1;
-    if (pass) {
-        for (let i = 1; i < chunk.length; ++i) {
-            if (chunk[i] instanceof RegExp) {
-                pass = pass && chunk[i].test(data[headIndex + i]);
-            } else {
-                pass = pass && this.equals(data[headIndex + i], chunk[i]);
-            }
-        }
-    }
-    return pass;
-    */
 }
 
 describe('Disclosure PDF generator', () => {
     it('returns a string of a PDF', async () => {
         const document = await generateDisclosure(submission, '1.2.3.4');
-
-        const donePromise = new Promise<void>((resolve, reject) => {
-            console.log('PDFParser: construct...');
-            const pdfParser = new PDFParser();
-
-            pdfParser.on('pdfParser_dataError', () => reject);
-
-            pdfParser.on('pdfParser_dataReady', () => {
-                /*
-                const jsonData = JSON.stringify(pdfParser.data);
-                console.log(jsonData);
-                expect(jsonData.includes('Our%20privacy%20policy')).toBe(true);
-                expect(jsonData.includes('Test%20User')).toBe(true);
-                expect(jsonData.includes('A.Scientist')).toBe(true);
-                */
-                resolve();
-            });
-
-            pdfParser.parseBuffer(document).catch(() => reject);
-        });
-
-        await donePromise;
+        expect(toContainChunk(document, Buffer.from(`5 0 obj\n<<\n/Length 5680\n`))).toBe(true);
     });
 });

--- a/src/domain/submission/services/exporter/file-generators/disclosure.test.ts
+++ b/src/domain/submission/services/exporter/file-generators/disclosure.test.ts
@@ -1,28 +1,59 @@
-import * as PDFParser from 'pdf2json';
 import { generateDisclosure } from './disclosure';
 import submission from './article.test.data';
 
-function toContainChunk(data: Buffer, chunk: Buffer): boolean {
-    let offset = 0;
-    do {
-        if (data[offset] === chunk[0]) {
-            for (let i = 1; i < chunk.length; i++) {
-                if (data[offset + i] !== chunk[i]) {
-                    break;
-                }
+function stringToHex(data: string): string {
+    let result = '';
+    for (let i = 0; i < data.length; i++) {
+        result += data.charCodeAt(i).toString(16);
+    }
+    console.log(`string: ${data}, hex: ${result}`);
+    return result;
+}
 
-                if (i + 1 === chunk.length) {
-                    return true;
-                }
-            }
+function pdfContainsText(pdf: Buffer, text: string): boolean {
+    const hexText = stringToHex(text);
+    let sectionStart = pdf.indexOf('[', 0);
+    while (sectionStart !== -1) {
+        const sectionEnd = pdf.indexOf(']', sectionStart);
+        if (sectionEnd === -1) {
+            return false;
         }
-    } while (++offset < data.length - chunk.length);
+
+        let segment = '';
+        let textChunkStart = pdf.indexOf('<', sectionStart);
+        while (textChunkStart > sectionStart && textChunkStart < sectionEnd) {
+            const textChunkEnd = pdf.indexOf('>', textChunkStart);
+
+            for (let i = textChunkStart + 1; i < textChunkEnd; i++) {
+                segment += String.fromCharCode(pdf[i]);
+            }
+
+            textChunkStart = pdf.indexOf('<', textChunkEnd);
+        }
+
+        if (segment === hexText) {
+            return true;
+        }
+
+        sectionStart = pdf.indexOf('[', sectionEnd);
+    }
     return false;
 }
 
 describe('Disclosure PDF generator', () => {
     it('returns a string of a PDF', async () => {
         const document = await generateDisclosure(submission, '1.2.3.4');
-        expect(toContainChunk(document, Buffer.from(`5 0 obj\n<<\n/Length 5680\n`))).toBe(true);
+        expect(pdfContainsText(document, `604e06ca-882d-4b5b-a147-e016893e60e9`)).toBe(true);
+        expect(pdfContainsText(document, `Test User`)).toBe(true);
+        expect(pdfContainsText(document, `A.Scientist`)).toBe(true);
+        expect(pdfContainsText(document, `1.2.3.4`)).toBe(true);
+        expect(pdfContainsText(document, `Disclosure of Data to Editors`)).toBe(true);
+        expect(
+            pdfContainsText(
+                document,
+                `Our privacy policy explains that we share your personal information with various third `,
+            ),
+        ).toBe(true);
+        expect(pdfContainsText(document, `I agree on behalf of all authors`)).toBe(true);
     });
 });

--- a/src/domain/submission/services/exporter/file-generators/disclosure.ts
+++ b/src/domain/submission/services/exporter/file-generators/disclosure.ts
@@ -23,7 +23,7 @@ export const generateDisclosure = (submission: Submission, clientIp: string): Pr
         'IP Address': clientIp,
     };
 
-    const doc = new PDFDocument();
+    const doc = new PDFDocument({ compress: false });
 
     const bold = 'Helvetica-Bold';
     const normal = 'Helvetica';


### PR DESCRIPTION
Reworked the disclosure test to no longer use `pdf2json`, although it can't yet be completely removed from the project as it is still used in the cover letter tests which use a different library, `html-pdf`, which introduces some more complexity.
As such, I've limited this PR to just resolving the issues with the disclosure test, and will create a new ticket to document the work to remove `pdf2json` completely.